### PR TITLE
Merged changes from nodejs/node 10.0.0 and 11.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: node_js
 node_js:
-  - 4
-  - 6
-  - 8
-script: npm test
+  - "8"
+  - "10"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ const urlToOptions = require('url-to-options');
 const url = new URL('http://user:pass@hostname:8080/');
 
 const opts = urlToOptions(url);
-//-> { auth:'user:pass', port:8080, &#x2026; }
+//-> { auth:'user:pass', port:8080, … }
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 ## Installation
 
-[Node.js](http://nodejs.org/) `>= 4` is required. To install, type this at the command line:
+[Node.js](http://nodejs.org/) `>= 8` is required. To install, type this at the command line:
 ```shell
 npm install url-to-options
 ```
@@ -19,7 +19,7 @@ const urlToOptions = require('url-to-options');
 const url = new URL('http://user:pass@hostname:8080/');
 
 const opts = urlToOptions(url);
-//-> { auth:'user:pass', port:8080, … }
+//-> { auth:'user:pass', port:8080, &#x2026; }
 ```
 
 

--- a/index.js
+++ b/index.js
@@ -7,13 +7,13 @@
 function urlToOptions(url) {
   var options = {
     protocol: url.protocol,
-    hostname: url.hostname.startsWith('[') ?
+    hostname: typeof url.hostname === 'string' && url.hostname.startsWith('[') ?
       url.hostname.slice(1, -1) :
       url.hostname,
     hash: url.hash,
     search: url.search,
     pathname: url.pathname,
-    path: `${url.pathname}${url.search}`,
+    path: `${url.pathname || ''}${url.search || ''}`,
     href: url.href
   };
   if (url.port !== '') {

--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@
 function urlToOptions(url) {
   var options = {
     protocol: url.protocol,
-    hostname: url.hostname,
+    hostname: url.hostname.startsWith('[') ?
+      url.hostname.slice(1, -1) :
+      url.hostname,
     hash: url.hash,
     search: url.search,
     pathname: url.pathname,

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "semver": "^6.0.0",
     "universal-url": "^2.0.0",
-    "whatwg-url": "^7.0.0"
+    "whatwg-url": "^5.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "author": "Steven Vachon <contact@svachon.com> (https://svachon.com)",
   "repository": "github:stevenvachon/url-to-options",
   "devDependencies": {
-    "semver": "^5.3.0",
-    "universal-url": "^1.0.0",
-    "whatwg-url": "^5.0.0"
+    "semver": "^6.0.0",
+    "universal-url": "^2.0.0",
+    "whatwg-url": "^7.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "whatwg-url": "^5.0.0"
   },
   "engines": {
-    "node": ">= 4"
+    "node": ">=4"
   },
   "scripts": {
     "test": "node test.js"

--- a/package.json
+++ b/package.json
@@ -7,11 +7,10 @@
   "repository": "github:stevenvachon/url-to-options",
   "devDependencies": {
     "semver": "^6.0.0",
-    "universal-url": "^2.0.0",
-    "whatwg-url": "^5.0.0"
+    "universal-url": "^2.0.0"
   },
   "engines": {
-    "node": ">=4"
+    "node": ">=8"
   },
   "scripts": {
     "test": "node test.js"

--- a/test.js
+++ b/test.js
@@ -9,7 +9,8 @@ const URL = require(semver.satisfies(process.version, '>= 6') ? 'universal-url' 
 
 // Copied from https://github.com/nodejs/node/blob/master/test/parallel/test-whatwg-url-properties.js
 
-const opts = urlToOptions(new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test'));
+const urlObj = new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test');
+const opts = urlToOptions(urlObj);
 assert.strictEqual(opts instanceof URL, false);
 assert.strictEqual(opts.protocol, 'http:');
 assert.strictEqual(opts.auth, 'user:pass');
@@ -22,3 +23,20 @@ assert.strictEqual(opts.hash, '#test');
 
 const { hostname } = urlToOptions(new URL('http://[::1]:21'));
 assert.strictEqual(hostname, '::1');
+
+// If a WHATWG URL object is copied, it is possible that the resulting copy
+// contains the Symbols that Node uses for brand checking, but not the data
+// properties, which are getters. Verify that urlToOptions() can handle such
+// a case.
+const copiedUrlObj = Object.assign({}, urlObj);
+const copiedOpts = urlToOptions(copiedUrlObj);
+assert.strictEqual(copiedOpts instanceof URL, false);
+assert.strictEqual(copiedOpts.protocol, undefined);
+assert.strictEqual(copiedOpts.auth, undefined);
+assert.strictEqual(copiedOpts.hostname, undefined);
+assert.strictEqual(copiedOpts.port, NaN);
+assert.strictEqual(copiedOpts.path, '');
+assert.strictEqual(copiedOpts.pathname, undefined);
+assert.strictEqual(copiedOpts.search, undefined);
+assert.strictEqual(copiedOpts.hash, undefined);
+assert.strictEqual(copiedOpts.href, undefined);

--- a/test.js
+++ b/test.js
@@ -3,7 +3,7 @@ const assert = require('assert');
 const semver = require('semver');
 const urlToOptions = require('./');
 
-const URL = require(semver.satisfies(process.version, '>= 6') ? 'universal-url' : 'whatwg-url').URL;
+const URL = require('universal-url').URL;
 
 
 

--- a/test.js
+++ b/test.js
@@ -3,11 +3,11 @@ const assert = require('assert');
 const semver = require('semver');
 const urlToOptions = require('./');
 
-const URL = require('universal-url').URL;
+const {URL} = require('universal-url');
 
 
 
-// Copied from https://github.com/nodejs/node/blob/master/test/parallel/test-whatwg-url-properties.js
+// Copied from https://github.com/nodejs/node/blob/master/test/parallel/test-whatwg-url-custom-properties.js
 
 const urlObj = new URL('http://user:pass@foo.bar.com:21/aaa/zzz?l=24#test');
 const opts = urlToOptions(urlObj);

--- a/test.js
+++ b/test.js
@@ -19,3 +19,6 @@ assert.strictEqual(opts.path, '/aaa/zzz?l=24');
 assert.strictEqual(opts.pathname, '/aaa/zzz');
 assert.strictEqual(opts.search, '?l=24');
 assert.strictEqual(opts.hash, '#test');
+
+const { hostname } = urlToOptions(new URL('http://[::1]:21'));
+assert.strictEqual(hostname, '::1');

--- a/test.js
+++ b/test.js
@@ -21,8 +21,7 @@ assert.strictEqual(opts.pathname, '/aaa/zzz');
 assert.strictEqual(opts.search, '?l=24');
 assert.strictEqual(opts.hash, '#test');
 
-const { hostname } = urlToOptions(new URL('http://[::1]:21'));
-assert.strictEqual(hostname, '::1');
+assert.strictEqual(urlToOptions(new URL('http://[::1]:21')).hostname, '::1');
 
 // If a WHATWG URL object is copied, it is possible that the resulting copy
 // contains the Symbols that Node uses for brand checking, but not the data
@@ -34,7 +33,7 @@ assert.strictEqual(copiedOpts instanceof URL, false);
 assert.strictEqual(copiedOpts.protocol, undefined);
 assert.strictEqual(copiedOpts.auth, undefined);
 assert.strictEqual(copiedOpts.hostname, undefined);
-assert.strictEqual(copiedOpts.port, NaN);
+(semver.satisfies(process.version, '>= 9') ? assert.strictEqual : Object.is)(copiedOpts.port, NaN);
 assert.strictEqual(copiedOpts.path, '');
 assert.strictEqual(copiedOpts.pathname, undefined);
 assert.strictEqual(copiedOpts.search, undefined);


### PR DESCRIPTION
* url: make urlToOptions() handle IPv6 literals
  Strip the enclosing square brackets from the parsed hostname.
  Merged from nodejs/node@fa2d43b

* url: handle quasi-WHATWG URLs in urlToOptions()
  Merged from nodejs/node@0017855

* Removed whitespace in node version field

* Updated devDependencies
  * Updated semver from `^5.3.0` to `^6.0.0`
  * Updated universal-url from `^1.0.0` to `^2.0.0`